### PR TITLE
Improve ONNX export and add visdom monitoring

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,145 @@
+import argparse
+import os
+from typing import List, Optional
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import DataLoader
+
+from dataset2d import Data
+from train2d import get_model
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Run inference with the best 2D segmentation model')
+    parser.add_argument('--dataset', type=str, default='prp')
+    parser.add_argument('--data_dir', type=str, default='./data/')
+    parser.add_argument('--checkpoint', type=str, default='./checkpoints/best_model.pth')
+    parser.add_argument('--output-dir', type=str, default='/output')
+    parser.add_argument('--onnx-path', type=str, default='./checkpoints/best_model.onnx')
+    parser.add_argument('--batchsize', type=int, default=1)
+    parser.add_argument('--crop_size', type=int, nargs='+', default=[512, 512], help='H, W')
+    parser.add_argument('--nclass', type=int, default=4)
+    parser.add_argument('--opset', type=int, default=11, help='ONNX opset version to use when exporting the model')
+    return parser.parse_args()
+
+
+def _normalize_class_to_gray(mask: np.ndarray, num_classes: int) -> np.ndarray:
+    if num_classes <= 1:
+        return np.zeros_like(mask, dtype=np.uint8)
+    scale = 255 // (num_classes - 1)
+    return (mask.astype(np.uint8) * scale).clip(0, 255).astype(np.uint8)
+
+
+def _names_from_batch(names, batch_index: int, batch_size: int) -> List[str]:
+    if isinstance(names, str):
+        return [names]
+    if isinstance(names, (list, tuple)) and all(isinstance(n, str) for n in names):
+        return list(names)
+    return [f'sample_{batch_index:04d}_{idx}' for idx in range(batch_size)]
+
+
+def save_predictions(segmentation_model: torch.nn.Module,
+                     dataloader: DataLoader,
+                     device: torch.device,
+                     output_dir: str,
+                     num_classes: int) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    segmentation_model.eval()
+
+    with torch.no_grad():
+        for batch_idx, batch in enumerate(dataloader):
+            images = batch['image'].to(device).float()
+            names = batch.get('name')
+            logits = segmentation_model(images)
+            predictions = torch.argmax(logits, dim=1).cpu().numpy().astype(np.uint8)
+
+            resolved_names = _names_from_batch(names, batch_idx, predictions.shape[0])
+
+            for idx, name in enumerate(resolved_names):
+                pred_map = predictions[idx]
+                gray_map = _normalize_class_to_gray(pred_map, num_classes)
+                save_path = os.path.join(output_dir, f'{name}.png')
+                Image.fromarray(gray_map, mode='L').save(save_path)
+
+
+def export_onnx(segmentation_model: torch.nn.Module,
+                onnx_path: str,
+                input_channels: int,
+                crop_size: Optional[List[int]],
+                opset: int) -> None:
+    if not onnx_path:
+        return
+
+    directory = os.path.dirname(onnx_path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+    if crop_size is None or len(crop_size) < 2:
+        raise ValueError('crop_size must provide width and height for ONNX export')
+
+    height, width = crop_size[1], crop_size[0]
+
+    model_device = next(segmentation_model.parameters()).device
+    if model_device.type != 'cuda':
+        if torch.cuda.is_available():
+            segmentation_model = segmentation_model.to('cuda')
+            model_device = torch.device('cuda')
+        else:
+            print('CUDA is not available; skipping ONNX export for CUDA-only model.')
+            return
+
+    segmentation_model = segmentation_model.eval()
+    dummy_input = torch.randn(1, input_channels, height, width, device=model_device)
+
+    torch.onnx.export(
+        segmentation_model,
+        dummy_input,
+        onnx_path,
+        input_names=['input'],
+        output_names=['output'],
+        opset_version=opset,
+        dynamic_axes={
+            'input': {0: 'batch', 2: 'height', 3: 'width'},
+            'output': {0: 'batch', 2: 'height', 3: 'width'}
+        }
+    )
+
+
+def main():
+    args = parse_args()
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    data_test = Data(base_dir=args.data_dir, train=False, dataset=args.dataset, crop_szie=args.crop_size)
+    input_channels = 3
+    if len(data_test) > 0:
+        sample = data_test[0]
+        input_channels = sample['image'].shape[0]
+
+    dataloader_test = DataLoader(
+        data_test,
+        batch_size=args.batchsize,
+        shuffle=False,
+        num_workers=4,
+        pin_memory=torch.cuda.is_available(),
+        drop_last=False
+    )
+
+    model = get_model(args, device=device)
+    state_dict = torch.load(args.checkpoint, map_location=device)
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    segmentation_model = model.model.to(device).eval()
+
+    save_predictions(segmentation_model, dataloader_test, device, args.output_dir, args.nclass)
+    print(f'Predictions saved to {os.path.abspath(args.output_dir)}')
+
+    export_onnx(segmentation_model, args.onnx_path, input_channels, args.crop_size, args.opset)
+    print(f'ONNX model exported to {os.path.abspath(args.onnx_path)}')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/predict_1.py
+++ b/predict_1.py
@@ -1,0 +1,145 @@
+import argparse
+import os
+from typing import List, Optional
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import DataLoader
+
+from dataset2d import Data
+from train2d import get_model
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Run inference with trained 2D segmentation model using weight.pkl')
+    parser.add_argument('--dataset', type=str, default='prp', help='Dataset name defined in dataset2d.Data')
+    parser.add_argument('--data_dir', type=str, default='./data/', help='Root directory that contains the dataset folders')
+    parser.add_argument('--weight-path', type=str, default='./weight.pkl', help='Path to the trained model weights saved as a pickle')
+    parser.add_argument('--output-dir', type=str, default='/output', help='Directory where predicted masks will be written')
+    parser.add_argument('--onnx-path', type=str, default='./test1.onnx', help='File path to export the ONNX model snapshot')
+    parser.add_argument('--batchsize', type=int, default=1, help='Batch size for inference')
+    parser.add_argument('--crop_size', type=int, nargs='+', default=[512, 512], help='Input size H W expected by the network')
+    parser.add_argument('--nclass', type=int, default=4, help='Number of segmentation classes')
+    parser.add_argument('--opset', type=int, default=11, help='ONNX opset version for export')
+    return parser.parse_args()
+
+
+def _normalize_class_to_gray(mask: np.ndarray, num_classes: int) -> np.ndarray:
+    if num_classes <= 1:
+        return np.zeros_like(mask, dtype=np.uint8)
+    scale = 255 // (num_classes - 1)
+    return (mask.astype(np.uint8) * scale).clip(0, 255).astype(np.uint8)
+
+
+def _names_from_batch(names, batch_index: int, batch_size: int) -> List[str]:
+    if isinstance(names, str):
+        return [names]
+    if isinstance(names, (list, tuple)) and all(isinstance(n, str) for n in names):
+        return list(names)
+    return [f'sample_{batch_index:04d}_{idx}' for idx in range(batch_size)]
+
+
+def save_predictions(segmentation_model: torch.nn.Module,
+                     dataloader: DataLoader,
+                     device: torch.device,
+                     output_dir: str,
+                     num_classes: int) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    segmentation_model.eval()
+
+    with torch.no_grad():
+        for batch_idx, batch in enumerate(dataloader):
+            images = batch['image'].to(device).float()
+            names = batch.get('name')
+
+            logits = segmentation_model(images)
+            predictions = torch.argmax(logits, dim=1).cpu().numpy().astype(np.uint8)
+
+            resolved_names = _names_from_batch(names, batch_idx, predictions.shape[0])
+
+            for idx, name in enumerate(resolved_names):
+                pred_map = predictions[idx]
+                gray_map = _normalize_class_to_gray(pred_map, num_classes)
+                save_path = os.path.join(output_dir, f'{name}.png')
+                Image.fromarray(gray_map, mode='L').save(save_path)
+
+
+def export_onnx(segmentation_model: torch.nn.Module,
+                onnx_path: str,
+                input_channels: int,
+                crop_size: Optional[List[int]],
+                opset: int) -> None:
+    if not onnx_path:
+        return
+
+    directory = os.path.dirname(onnx_path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+    if crop_size is None or len(crop_size) < 2:
+        raise ValueError('crop_size must provide width and height for ONNX export')
+
+    height, width = crop_size[1], crop_size[0]
+
+    model_device = next(segmentation_model.parameters()).device
+    if model_device.type != 'cuda':
+        if torch.cuda.is_available():
+            segmentation_model = segmentation_model.to('cuda')
+            model_device = torch.device('cuda')
+        else:
+            print('CUDA is not available; skipping ONNX export for CUDA-only model.')
+            return
+
+    segmentation_model = segmentation_model.eval()
+    dummy_input = torch.randn(1, input_channels, height, width, device=model_device)
+
+    torch.onnx.export(
+        segmentation_model,
+        dummy_input,
+        onnx_path,
+        input_names=['input'],
+        output_names=['output'],
+        opset_version=opset,
+        dynamic_axes={
+            'input': {0: 'batch', 2: 'height', 3: 'width'},
+            'output': {0: 'batch', 2: 'height', 3: 'width'}
+        }
+    )
+
+
+def main():
+    args = parse_args()
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    data_test = Data(base_dir=args.data_dir, train=False, dataset=args.dataset, crop_szie=args.crop_size)
+    input_channels = 3
+    if len(data_test) > 0:
+        sample = data_test[0]
+        input_channels = sample['image'].shape[0]
+
+    dataloader_test = DataLoader(
+        data_test,
+        batch_size=args.batchsize,
+        shuffle=False,
+        num_workers=4,
+        pin_memory=torch.cuda.is_available(),
+        drop_last=False
+    )
+
+    model = get_model(args, device=device)
+    state_dict = torch.load(args.weight_path, map_location=device)
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    segmentation_model = model.model.to(device).eval()
+
+    save_predictions(segmentation_model, dataloader_test, device, args.output_dir, args.nclass)
+    print(f'Predictions saved to {os.path.abspath(args.output_dir)}')
+
+    export_onnx(segmentation_model, args.onnx_path, input_channels, args.crop_size, args.opset)
+    print(f'ONNX model exported to {os.path.abspath(args.onnx_path)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/test2d.py
+++ b/test2d.py
@@ -1,3 +1,6 @@
+import os
+from typing import Any, Optional
+
 import torch
 import numpy as np
 import torch.nn.functional as F
@@ -5,6 +8,7 @@ from train2d import get_model
 import argparse
 from torch.utils.data import DataLoader
 from dataset2d import Data
+from PIL import Image
 
 
 
@@ -61,11 +65,25 @@ class Evaluator:
             (self.Accuracy ) *100 ,np.mean(self.Dice ) *100 ,np.mean(self.IoU) *100
 
 
-def Eval(dataloader_test, model, args2):
+def _ensure_list(value: Any) -> list:
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def Eval(dataloader_test, model, args2,
+         vis_reporter: Optional[Any] = None,
+         epoch: Optional[int] = None,
+         save_dir: Optional[str] = None):
 
     model.eval()
+    summary = {'dataset': args2.dataset}
+
     if args2.dataset in ['ISIC16', 'ISIC18']:
         evaluator = Evaluator()
+
+    if args2.dataset in ['prp']:
+        evaluators = [Evaluator() for _ in range(args2.nclass)]
 
     if args2.dataset in ['acdc']:
         evaluator_RV =  Evaluator()
@@ -83,12 +101,34 @@ def Eval(dataloader_test, model, args2):
         evaluator_Sp = Evaluator()
         evaluator_St = Evaluator()
 
+    epoch_dir = None
+    if save_dir is not None and epoch is not None:
+        epoch_dir = os.path.join(save_dir, f'epoch_{epoch:03d}')
+        os.makedirs(epoch_dir, exist_ok=True)
+
+    visualized = False
+
     with torch.no_grad():
         for i, sample in enumerate(dataloader_test):
-            image, label = sample['image'], sample['label']
-            image, label = image.cuda(), label.cuda()
-            label = label.long().squeeze(1)
-            logit = model(image, label, False)
+            image = sample['image'].cuda().float()
+            label = sample['label'].cuda()
+            label_indices = sample['label_indices'].cuda()
+
+            if label_indices.dim() == 4 and label_indices.size(1) == 1:
+                label_indices = label_indices.squeeze(1)
+            label_indices = label_indices.long()
+
+            logit = model(image, label_indices, False)
+            predictions_indices = torch.argmax(logit, dim=1)
+
+            if epoch_dir is not None:
+                names = _ensure_list(sample.get('name', f'sample_{i:04d}'))
+                scale = 255 // (max(args2.nclass - 1, 1)) if args2.nclass > 1 else 0
+                for b in range(predictions_indices.size(0)):
+                    mask = predictions_indices[b].detach().cpu().numpy().astype(np.uint8)
+                    gray = (mask * scale).clip(0, 255).astype(np.uint8)
+                    name = names[b] if b < len(names) else f'sample_{i:04d}_{b}'
+                    Image.fromarray(gray, mode='L').save(os.path.join(epoch_dir, f'{name}.png'))
 
 
             if args2.dataset in ['ISIC16', 'ISIC18']:
@@ -96,14 +136,30 @@ def Eval(dataloader_test, model, args2):
 
                 predictions = torch.argmax(logit, dim=1)
                 predictions = F.one_hot(predictions.long(), num_classes=args2.nclass)
-                new_labels = F.one_hot(label.long(), num_classes=args2.nclass)
+                new_labels = F.one_hot(label_indices.long(), num_classes=args2.nclass)
                 evaluator.update(predictions[0, :, :, 1], new_labels[0, :, :, 1].float())
+
+
+            if args2.dataset in ['prp']:
+                predictions = torch.argmax(logit, dim=1)
+                pred = F.one_hot(predictions.long(), num_classes=args2.nclass).permute(0, 3, 1, 2)
+                if label.dim() == 4 and label.size(1) == args2.nclass:
+                    new_labels = label.float()
+                else:
+                    new_labels = F.one_hot(label_indices.long(), num_classes=args2.nclass).permute(0, 3, 1, 2).float()
+
+                for cls_idx in range(args2.nclass):
+                    evaluators[cls_idx].update(pred[0, cls_idx], new_labels[0, cls_idx])
+
+                if vis_reporter is not None and not visualized:
+                    vis_reporter.show_sample('val', image[0], pred[0], new_labels[0])
+                    visualized = True
 
 
             if args2.dataset in ['synapse']:
                 predictions = torch.argmax(logit, dim=1)
                 pred = F.one_hot(predictions.long(), num_classes=args2.nclass)
-                new_labels = F.one_hot(label.long(), num_classes=args2.nclass)
+                new_labels = F.one_hot(label_indices.long(), num_classes=args2.nclass)
 
                 evaluator_A.update(pred[0, :, :, 1], new_labels[0, :, :, 1].float())
                 evaluator_G.update(pred[0, :, :, 2], new_labels[0, :, :, 2].float())
@@ -118,7 +174,7 @@ def Eval(dataloader_test, model, args2):
             if args2.dataset in ['acdc']:
                 predictions = torch.argmax(logit, dim=1)
                 pred = F.one_hot(predictions.long(), num_classes=args2.nclass)
-                new_labels = F.one_hot(label.long(), num_classes=args2.nclass)
+                new_labels = F.one_hot(label_indices.long(), num_classes=args2.nclass)
                 evaluator_RV.update(pred[0, :, :, 1], new_labels[0, :, :, 1].float())
                 evaluator_Myo.update(pred[0, :, :, 2], new_labels[0, :, :, 2].float())
                 evaluator_LV.update(pred[0, :, :, 3], new_labels[0, :, :, 3].float())
@@ -129,6 +185,46 @@ def Eval(dataloader_test, model, args2):
         MAE, Rec, Pre, Acc, Dice, IoU = evaluator.show(False)
         print("MAE: ", "%.2f" % MAE, "  Recall: ", "%.2f" % Rec, " Pre: ", "%.2f" % Pre,
               " Acc: ", "%.2f" % Acc, " Dice: ", "%.2f" % Dice, " IoU: ", "%.2f" % IoU)
+        summary['average'] = {
+            'MAE': float(MAE),
+            'Recall': float(Rec),
+            'Precision': float(Pre),
+            'Accuracy': float(Acc),
+            'Dice': float(Dice),
+            'IoU': float(IoU)
+        }
+
+
+    if args2.dataset in ['prp']:
+        metrics = [ev.show(False) for ev in evaluators]
+        class_names = [f'Class_{idx}' for idx in range(args2.nclass)]
+        per_class = []
+        for cls_name, metric in zip(class_names, metrics):
+            MAE, Rec, Pre, Acc, Dice, IoU = metric
+            print(f"{cls_name} -> MAE: {MAE:.2f}  Recall: {Rec:.2f}  Pre: {Pre:.2f}  Acc: {Acc:.2f}  Dice: {Dice:.2f}  IoU: {IoU:.2f}")
+            per_class.append({
+                'Class': cls_name,
+                'MAE': float(MAE),
+                'Recall': float(Rec),
+                'Precision': float(Pre),
+                'Accuracy': float(Acc),
+                'Dice': float(Dice),
+                'IoU': float(IoU)
+            })
+
+        averaged = np.mean(np.array(metrics), axis=0)
+        MAE, Rec, Pre, Acc, Dice, IoU = averaged
+        print("Average -> MAE: %.2f  Recall: %.2f  Pre: %.2f  Acc: %.2f  Dice: %.2f  IoU: %.2f" %
+              (MAE, Rec, Pre, Acc, Dice, IoU))
+        summary['per_class'] = per_class
+        summary['average'] = {
+            'MAE': float(MAE),
+            'Recall': float(Rec),
+            'Precision': float(Pre),
+            'Accuracy': float(Acc),
+            'Dice': float(Dice),
+            'IoU': float(IoU)
+        }
 
 
     if args2.dataset in ['acdc']:
@@ -144,6 +240,14 @@ def Eval(dataloader_test, model, args2):
         IoU = (IoU_RV + IoU_Myo + IoU_LV) / 3
         print("MAE: ", "%.2f" % MAE, "  Recall: ", "%.2f" % Rec, " Pre: ", "%.2f" % Pre,
               " Acc: ", "%.2f" % Acc, " Dice: ", "%.2f" % Dice, " IoU: ", "%.2f" % IoU)
+        summary['average'] = {
+            'MAE': float(MAE),
+            'Recall': float(Rec),
+            'Precision': float(Pre),
+            'Accuracy': float(Acc),
+            'Dice': float(Dice),
+            'IoU': float(IoU)
+        }
 
 
 
@@ -163,10 +267,16 @@ def Eval(dataloader_test, model, args2):
         Acc = (Acc_A + Acc_G + Acc_LK + Acc_RK + Acc_L + Acc_P + Acc_Sp + Acc_St) / 8
         Dice = (Dice_A + Dice_G + Dice_LK + Dice_RK + Dice_L + Dice_P + Dice_Sp + Dice_St) / 8
         IoU = (IoU_A + IoU_G + IoU_LK + IoU_RK + IoU_L + IoU_P + IoU_Sp + IoU_St) / 8
+        summary['average'] = {
+            'MAE': float(MAE),
+            'Recall': float(Rec),
+            'Precision': float(Pre),
+            'Accuracy': float(Acc),
+            'Dice': float(Dice),
+            'IoU': float(IoU)
+        }
 
-
-        print("MAE: ", "%.2f" % MAE, "  Recall: ", "%.2f" % Rec, " Pre: ", "%.2f" % Pre,
-              " Acc: ", "%.2f" % Acc, " Dice: ", "%.2f" % Dice, " IoU: ", "%.2f" % IoU)
+    return summary
 
 
 def parse_args():


### PR DESCRIPTION
## Summary
- keep ONNX exports on the model's CUDA device, provide dynamic input validation, and write grayscale prediction masks with deterministic names
- add a Visdom reporter to surface training and validation samples (input plus four class channels) and allow disabling or configuring the server via CLI flags
- persist grayscale validation predictions per epoch so the PRP dataset results can be inspected offline

## Testing
- python -m compileall predict_1.py predict.py train2d.py test2d.py

------
https://chatgpt.com/codex/tasks/task_e_68d63dae7240832eb1ce935865e210b9