### PR TITLE
Make fallback scan ONNX friendly

### DIFF
--- a/Zig_RiR2d.py
+++ b/Zig_RiR2d.py
@@ -128,7 +128,9 @@ def _wkv_fallback_scan(
     first = first.view(first.size(0), 1, first.size(1)).expand(B, T, C)
 
     ones = torch.ones((B, 1, C), dtype=k.dtype, device=k.device)
-    decay_cumprod = torch.cumprod(decay, dim=1)
+    log_decay = torch.log(decay)
+    decay_cumsum = torch.cumsum(log_decay, dim=1)
+    decay_cumprod = torch.exp(decay_cumsum)
     decay_prefix = torch.cat((ones, decay_cumprod[:, :-1, :]), dim=1)
     decay_prefix_inv = torch.reciprocal(decay_prefix)
 


### PR DESCRIPTION
## Summary
- replace the cumulative product in `_wkv_fallback_scan` with a log/sum/exp formulation to avoid `torch.cumprod`

## Testing
- not run (torch is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d94e163dfc832eb687ec29f79a5d33