### PR TITLE
Improve ONNX export compatibility

### DIFF
--- a/train2d.py
+++ b/train2d.py
@@ -199,7 +199,7 @@ def export_trained_model_to_onnx(args2, checkpoint_path: str) -> None:
         print(f'ONNX export skipped because checkpoint {checkpoint_path} was not found.')
         return
 
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = torch.device('cpu')
     segmentation_model = build_segmentation_model(args2, device=device)
     state_dict = torch.load(checkpoint_path, map_location=device)
     segmentation_model.load_state_dict(state_dict)


### PR DESCRIPTION
## Summary
- refactor spatial mixing utilities to avoid Python scalar conversions during tracing
- adjust patch merging and feature reshaping logic to rely on tensor-derived dimensions
- run ONNX export on the CPU to prevent device mismatches during constant folding

## Testing
- python -m compileall Zig_RiR2d.py train2d.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ea9ff7dc832eae7fd698a8a6c311